### PR TITLE
Update for TWW

### DIFF
--- a/DHE_main.lua
+++ b/DHE_main.lua
@@ -277,8 +277,7 @@ function DHE_events:UNIT_AURA(...)
     end
     -- Check if the player hopped into meta just now
     local isInMeta = false
-    for i=1,40 do
-        local name = UnitBuff("player",i)
+    AuraUtil.ForEachAura("player", "HELPFUL", nil, function(name, ...)
         if name == "Metamorphosis" then
             isInMeta = true
             if not DHE_playerInMetamorphosis then
@@ -286,7 +285,7 @@ function DHE_events:UNIT_AURA(...)
                 DHE_handleSoundEvent("META", true)
             end
         end
-    end
+    end)
     if not isInMeta and DHE_playerInMetamorphosis then
         DHE_playerInMetamorphosis = false
     end

--- a/DemonHunterExperience.toc
+++ b/DemonHunterExperience.toc
@@ -1,4 +1,4 @@
-## Interface: 100002
+## Interface: 110007
 ## Title: Demon Hunter Experience
 ## Notes: Restores the true Demon Hunter Experience
 ## Author: jroweboy


### PR DESCRIPTION
Previous UnitBuff is deprecated as of the TWW  expansion: https://warcraft.wiki.gg/wiki/Patch_10.2.5/API_changes

Replaces previous UnitBuff  loop with AuraUtil.ForEachAura loop instead